### PR TITLE
find resource with binding annotation

### DIFF
--- a/apis/infra/v1alpha1/cluster_types.go
+++ b/apis/infra/v1alpha1/cluster_types.go
@@ -28,11 +28,6 @@ type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// ScaleProfileName contains the name of a ClusterScaleProfile in the same namespace,
-	// which provides cluster scaling characteristics
-	// +optional
-	ScaleProfileName *string `json:"scaleProfileName,omitempty"`
-
 	// RepositoryRef identifies the deployment repository for this cluster
 	RepositoryRef automationv1alpha1.RepositoryReference `json:"repositoryRef"`
 }

--- a/apis/infra/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/infra/v1alpha1/zz_generated.deepcopy.go
@@ -30,11 +30,6 @@ func (in *Cluster) DeepCopyInto(out *Cluster) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	if in.ScaleProfileName != nil {
-		in, out := &in.ScaleProfileName, &out.ScaleProfileName
-		*out = new(string)
-		**out = **in
-	}
 	out.RepositoryRef = in.RepositoryRef
 }
 

--- a/config/crd/bases/infra.nephio.org_clusters.yaml
+++ b/config/crd/bases/infra.nephio.org_clusters.yaml
@@ -47,10 +47,6 @@ spec:
             required:
             - name
             type: object
-          scaleProfileName:
-            description: ScaleProfileName contains the name of a ClusterScaleProfile
-              in the same namespace, which provides cluster scaling characteristics
-            type: string
         required:
         - repositoryRef
         type: object

--- a/config/samples/infra_v1alpha1_cluster.yaml
+++ b/config/samples/infra_v1alpha1_cluster.yaml
@@ -6,7 +6,6 @@ metadata:
     nephio.org/region: us-central1
     nephio.org/site-type: regional
     nephio.org/site: us-central1
-scaleProfileName: large-autoscaling-site
 repositoryRef:
   name: test-deploy-regional-01
 ---
@@ -18,7 +17,6 @@ metadata:
     nephio.org/region: us-central1
     nephio.org/site-type: aggregation
     nephio.org/site: edge-01
-scaleProfileName: small-fixed-site
 repositoryRef:
   name: test-deploy-edge-01
 ---
@@ -30,6 +28,5 @@ metadata:
     nephio.org/region: us-central1
     nephio.org/site-type: aggregation
     nephio.org/site: edge-02
-scaleProfileName: medium-fixed-site
 repositoryRef:
   name: test-deploy-edge-02

--- a/config/samples/infra_v1alpha1_clusterscaleprofile.yaml
+++ b/config/samples/infra_v1alpha1_clusterscaleprofile.yaml
@@ -1,7 +1,7 @@
 apiVersion: infra.nephio.org/v1alpha1
 kind: ClusterScaleProfile
 metadata:
-  name: small-fixed-site
+  name: nephio-edge-01
 spec:
   autoscaling: false
   nodeMax: 6
@@ -10,7 +10,7 @@ spec:
 apiVersion: infra.nephio.org/v1alpha1
 kind: ClusterScaleProfile
 metadata:
-  name: medium-fixed-site
+  name: nephio-edge-02
 spec:
   autoscaling: false
   nodeMax: 12
@@ -37,7 +37,7 @@ spec:
 apiVersion: infra.nephio.org/v1alpha1
 kind: ClusterScaleProfile
 metadata:
-  name: large-autoscaling-site
+  name: nephio-regional-01
 spec:
   autoscaling: true
   nodeMax: 2400

--- a/controllers/automation/packagedeployment_controller.go
+++ b/controllers/automation/packagedeployment_controller.go
@@ -232,15 +232,15 @@ metadata:
 	for id, pkgResource := range bindingResources {
 		clusterResource, err := r.findClusterObject(ctx, c, id)
 		if err != nil {
-			r.l.Error(err, "error finding cluster resource", "cluster", c)
-			return err
+			r.l.Info(fmt.Sprintf("error finding cluster resource: %s", err.Error()), "cluster", c)
+			continue
 		}
 		if clusterResource != nil {
-
 			// convert it to a *RNode
 			var spYamlBuf bytes.Buffer
 			if err := r.s.Encode(clusterResource, &spYamlBuf); err != nil {
-				r.l.Error(err, "could not write clusterScaleProfile as yaml", "clusterResource", clusterResource)
+				r.l.Error(err, fmt.Sprintf("could not write resource with apiVersion %q and kind %q as yaml",
+					id.APIVersion, id.Kind), "clusterResource", clusterResource)
 				return err
 			}
 

--- a/controllers/automation/packagedeployment_controller.go
+++ b/controllers/automation/packagedeployment_controller.go
@@ -19,15 +19,21 @@ package automation
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/kustomize/kyaml/resid"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	"github.com/go-logr/logr"
 
@@ -36,8 +42,6 @@ import (
 
 	porchv1alpha1 "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/nephio-controller-poc/pkg/porch"
-
-	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 // namespace->repo->package->revision
@@ -45,6 +49,8 @@ type PackageRevisionMapByRev map[string]*porchv1alpha1.PackageRevision
 type PackageRevisionMapByPkg map[string]PackageRevisionMapByRev
 type PackageRevisionMapByRepo map[string]PackageRevisionMapByPkg
 type PackageRevisionMapByNS map[string]PackageRevisionMapByRepo
+
+var wsNum = 0
 
 // PackageDeploymentReconciler reconciles a PackageDeployment object
 type PackageDeploymentReconciler struct {
@@ -73,6 +79,7 @@ type PackageDeploymentReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
 func (r *PackageDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	pd, err := r.startRequest(ctx, req)
+	r.l.Info("reconciling")
 
 	// Find the clusters matching the selector
 	selector, err := metav1.LabelSelectorAsSelector(pd.Spec.Selector)
@@ -142,6 +149,10 @@ func (r *PackageDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			continue
 		}
 
+		if newPR == nil {
+			continue
+		}
+
 		if err := r.applyPackageMutations(ctx, targetNS, &c, newPR); err != nil {
 			r.l.Error(err, "could not apply package mutations")
 			continue
@@ -173,17 +184,28 @@ func (r *PackageDeploymentReconciler) applyPackageMutations(ctx context.Context,
 
 	r.l.Info("parsed resources", "resources", pkgBuf)
 
-	// search for NS and ScaleProfile resources
 	nsIdx := -1
-	scaleProfileIdx := -1
+	bindingResources := make(map[yaml.ResourceIdentifier]*yaml.RNode)
 	for i, n := range pkgBuf.Nodes {
+		// search for namespace
 		if n.GetApiVersion() == "v1" && n.GetKind() == "Namespace" {
 			nsIdx = i
-			continue
 		}
-		if n.GetApiVersion() == "infra.nephio.org/v1alpha1" && n.GetKind() == "ClusterScaleProfile" {
-			scaleProfileIdx = i
-			continue
+
+		// search for binding resources
+		annotations := n.GetAnnotations()
+		if value, found := annotations["config.kubernetes.io/local-config"]; found && value == "binding" {
+			id := yaml.ResourceIdentifier{
+				TypeMeta: yaml.TypeMeta{
+					APIVersion: n.GetApiVersion(),
+					Kind:       n.GetKind(),
+				},
+				NameMeta: yaml.NameMeta{
+					Name:      n.GetName(),
+					Namespace: n.GetNamespace(),
+				},
+			}
+			bindingResources[id] = n
 		}
 	}
 
@@ -203,20 +225,22 @@ metadata:
 		pkgBuf.Nodes = append(pkgBuf.Nodes, nsNode)
 	}
 
-	// If a ClusterScaleProfile CR exists, and one exists for the
-	// associated cluster, then copy the cluster version to the package
-	if scaleProfileIdx > -1 {
-		clusterScaleProfile, err := r.findClusterScaleProfile(ctx, c)
+	// If a binding resource exists in the package, and one exists
+	// that matches the name of the associated cluster, overwrite the
+	// resource in the package with the cluster resource
+
+	for id, pkgResource := range bindingResources {
+		clusterResource, err := r.findClusterObject(ctx, c, id)
 		if err != nil {
-			r.l.Error(err, "error finding cluster scale profile", "cluster", c)
+			r.l.Error(err, "error finding cluster resource", "cluster", c)
 			return err
 		}
-		if clusterScaleProfile != nil {
+		if clusterResource != nil {
 
 			// convert it to a *RNode
 			var spYamlBuf bytes.Buffer
-			if err := r.s.Encode(clusterScaleProfile, &spYamlBuf); err != nil {
-				r.l.Error(err, "could not write clusterScaleProfile as yaml", "clusterScaleProfile", clusterScaleProfile)
+			if err := r.s.Encode(clusterResource, &spYamlBuf); err != nil {
+				r.l.Error(err, "could not write clusterScaleProfile as yaml", "clusterResource", clusterResource)
 				return err
 			}
 
@@ -228,7 +252,11 @@ metadata:
 
 			// set the spec on the one in the package to match our spec
 			field := spNode.Field("spec")
-			pkgBuf.Nodes[scaleProfileIdx].SetMapField(field.Value, "spec")
+			if err := pkgResource.SetMapField(field.Value, "spec"); err != nil {
+				str, _ := spNode.String()
+				r.l.Error(err, "could not set object spec", "spNode", str)
+				return err
+			}
 		}
 	}
 
@@ -252,21 +280,26 @@ metadata:
 	return nil
 }
 
-func (r *PackageDeploymentReconciler) findClusterScaleProfile(ctx context.Context, c *infrav1alpha1.Cluster) (*infrav1alpha1.ClusterScaleProfile, error) {
-	if c.ScaleProfileName == nil {
-		return nil, nil
-	}
+func (r *PackageDeploymentReconciler) findClusterObject(ctx context.Context, c *infrav1alpha1.Cluster,
+	id yaml.ResourceIdentifier) (*unstructured.Unstructured, error) {
 
-	var scaleProfile infrav1alpha1.ClusterScaleProfile
+	u := &unstructured.Unstructured{}
+	group, version := resid.ParseGroupVersion(id.APIVersion)
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   group,
+		Kind:    id.Kind,
+		Version: version,
+	})
+
 	if err := r.Client.Get(ctx, client.ObjectKey{
 		Namespace: c.Namespace,
-		Name:      *c.ScaleProfileName,
-	}, &scaleProfile); err != nil {
-		r.l.Error(err, "unable to fetch ClusterScaleProfile", "cluster", c)
+		Name:      c.Name,
+	}, u); err != nil {
+		r.l.Error(err, "unable to fetch object from cluster", "cluster", c)
 		return nil, err
 	}
 
-	return &scaleProfile, nil
+	return u, nil
 }
 
 func (r *PackageDeploymentReconciler) startRequest(ctx context.Context, req ctrl.Request) (*automationv1alpha1.PackageDeployment, error) {
@@ -375,6 +408,17 @@ func (r *PackageDeploymentReconciler) ensurePackageRevision(ctx context.Context,
 		newPackageName = *pd.Spec.Namespace
 	}
 
+	// check if the package already exists downstream
+	if byRepo, ok := r.packageRevs[ns]; ok {
+		if byPkg, ok := byRepo[c.RepositoryRef.Name]; ok {
+			if _, ok := byPkg[newPackageName]; ok {
+				// downstream package already exists
+				// TODO: Update the downstream package if needed.
+				return nil, nil
+			}
+		}
+	}
+
 	// We SHOULD be adding an ownerRef with the controller and PD info,
 	// This would be to facilitate pruning. I am not sure if the aggregated
 	// API server in Porch supports this; if not we need to add it.
@@ -391,7 +435,7 @@ func (r *PackageDeploymentReconciler) ensurePackageRevision(ctx context.Context,
 			//PackageName:    sourcePR.Spec.PackageName,
 			//Revision:       sourcePR.Spec.Revision,
 			PackageName:    newPackageName,
-			Revision:       "v1",
+			WorkspaceName:  porchv1alpha1.WorkspaceName(fmt.Sprintf("ws-%d", wsNum)),
 			RepositoryName: c.RepositoryRef.Name,
 			Tasks: []porchv1alpha1.Task{
 				{
@@ -411,6 +455,8 @@ func (r *PackageDeploymentReconciler) ensurePackageRevision(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+
+	wsNum++
 
 	r.l.Info("Created PackageRevision", "newPR", newPR)
 	return newPR, nil

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/nephio-project/nephio-controller-poc
 go 1.18
 
 require (
-	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220808214113-655377b65d42
+	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20221101221205-3f3fbb8b507d
 	github.com/go-logr/logr v1.2.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220808214113-655377b65d42 h1:VI58jVGAL42V+39R+axygy5d40ByEcV1xiqu0wK2+kI=
 github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220808214113-655377b65d42/go.mod h1:51Vk7QZ+XUzHCvQBi7t9tiWqTXvy6T13cv/inUXJJ0s=
+github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20221101221205-3f3fbb8b507d h1:ggKkI4gfKE/hg+ZjUJtsNo3WKkMmmfDEO1vR1sEKz2M=
+github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20221101221205-3f3fbb8b507d/go.mod h1:ASrhnLAL4ahTuiUJyepqcpVRXIoRMJyDs8/eSxwhgZM=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
As discussed, this PR makes it so that the packagedeployment controller looks for the annotation `config.kubernetes.io/local-config: "binding"` to determine whether it should compare the resources to the cluster, and then compare by GVK and the cluster name - rather than just looking at the ClusterScaleProfile resource specifically. 

Here are the sample files I used to test this. This particular example binds the package's ClusterScaleProfile object.

Upstream package:
- Link: https://github.com/natasha41575/blueprints/tree/foo/v2/foo

Downstream package:
- Link: https://github.com/natasha41575/deployments/tree/drafts/default/ws-0/default
- This was created by the controller; note that the spec in `scale.yaml` differs from the upstream one because it was overwritten by the in-cluster resource spec

In-cluster resources:

scale.yaml:
```
apiVersion: infra.nephio.org/v1alpha1
kind: ClusterScaleProfile
metadata:
  annotations:
    config.kubernetes.io/local-config: binding
spec:
  autoscaling: true
```

cluster.yaml:
```
apiVersion: infra.nephio.org/v1alpha1
kind: Cluster
metadata:
  name: nginx
  labels:
    foo: bar
repositoryRef:
  namespace: default
  name: deployments
```

packagedeployment.yaml
```
apiVersion: automation.nephio.org/v1alpha1
kind: PackageDeployment
metadata:
  name: my-pd
spec:
  selector:
    matchLabels:
      foo: bar
  packageRef:
    repository: blueprints
    packageName: foo
    revision: v2
  namespace: default
```

