### PR TITLE
update includefile to deal with sub-directories  xxx/file.yaml

### DIFF
--- a/pkg/porch/util.go
+++ b/pkg/porch/util.go
@@ -126,7 +126,8 @@ var matchResourceContents = append(kio.MatchAll, "Kptfile")
 
 func includeFile(path string) bool {
 	for _, m := range matchResourceContents {
-		if matched, err := filepath.Match(m, path); err == nil && matched {
+		file := filepath.Base(path)
+		if matched, err := filepath.Match(m, file); err == nil && matched {
 			return true
 		}
 	}


### PR DESCRIPTION
When a file contains subdirectories like default/file.yaml, the match does not work.