### PR TITLE
Improved error handling when a pd gets deleted

### DIFF
--- a/controllers/automation/packagedeployment_controller.go
+++ b/controllers/automation/packagedeployment_controller.go
@@ -89,6 +89,14 @@ type PackageDeploymentReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
 func (r *PackageDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	pd, err := r.startRequest(ctx, req)
+	if err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			r.l.Error(err, "cannot get pd")
+			return ctrl.Result{}, err
+		}
+		r.l.Info("cannot get resource, probably deleted", "error", err.Error())
+		return ctrl.Result{}, nil
+	}
 
 	// Find the clusters matching the selector
 	selector, err := metav1.LabelSelectorAsSelector(pd.Spec.Selector)

--- a/pkg/porch/util.go
+++ b/pkg/porch/util.go
@@ -126,7 +126,8 @@ var matchResourceContents = append(kio.MatchAll, "Kptfile")
 
 func includeFile(path string) bool {
 	for _, m := range matchResourceContents {
-		if matched, err := filepath.Match(m, path); err == nil && matched {
+		file := filepath.Base(path)
+		if matched, err := filepath.Match(m, file); err == nil && matched {
 			return true
 		}
 	}


### PR DESCRIPTION
currently we crash with a nil pointer when a pd is deleted.
So we should return when a pd is deleted and stop the reconcile loop